### PR TITLE
moved _read_rt_lookup_file to ident base parser

### DIFF
--- a/tests/ident/test_engine_parser_xtandem_alanine.py
+++ b/tests/ident/test_engine_parser_xtandem_alanine.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -150,25 +151,28 @@ def test_get_single_spec_df():
     assert isinstance(result, pd.DataFrame)
     assert (
         result.values
-        == [
-            None,
-            "1315.5700",
-            "test_Creinhardtii_QE_pH11.10381.10381.3",
-            "path/for/glory.mgf",
-            "xtandem_alanine",
-            "10381",
-            list(["15.99492:5"]),
-            None,
-            "0.0057",
-            "8.0",
-            "9.9",
-            "5",
-            "0.0",
-            "0",
-            "DDVHNMGADGIR",
-            "3",
-            "14.2",
-        ]
+        == np.array(
+            [
+                None,
+                "1315.5700",
+                "test_Creinhardtii_QE_pH11.10381.10381.3",
+                "path/for/glory.mgf",
+                "xtandem_alanine",
+                "10381",
+                list(["15.99492:5"]),
+                None,
+                "0.0057",
+                "8.0",
+                "9.9",
+                "5",
+                "0.0",
+                "0",
+                "DDVHNMGADGIR",
+                "3",
+                "14.2",
+            ],
+            dtype=object,
+        )
     ).all()
 
 

--- a/tests/test_engine_parser_base_parser.py
+++ b/tests/test_engine_parser_base_parser.py
@@ -5,17 +5,9 @@ import pytest
 from unify_idents.engine_parsers.base_parser import BaseParser
 
 
-def test_base_parser_read_rt_lookup_file():
-    rt_lookup_path = Path(__file__).parent / "data" / "BSA1_ursgal_lookup.csv.bz2"
+def test_uninitialized_parser_compatiblity_is_false():
     input_file = (
-        Path(__file__).parent / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
+        pytest._test_path / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
     )
-
-    bp = BaseParser(input_file, params={"rt_pickle_name": rt_lookup_path})
-    rt_lookup = bp._read_rt_lookup_file()
-    assert (rt_lookup["Unit"] == 1).all()
-    assert pytest.approx(
-        rt_lookup["Precursor mz"].mean(), 550.8444810049874
-    )  # check consistency
-    assert pytest.approx(rt_lookup.loc[2450, "Precursor mz"], 618.2697)
-    assert pytest.approx(rt_lookup.loc[2450, "RT"], 92067.714)
+    compat = BaseParser.check_parser_compatibility(input_file)
+    assert compat is False

--- a/tests/test_engine_parser_ident_base_parser.py
+++ b/tests/test_engine_parser_ident_base_parser.py
@@ -11,12 +11,28 @@ from unify_idents.engine_parsers.base_parser import (
 )
 
 
+def test_base_parser_read_rt_lookup_file():
+    rt_lookup_path = pytest._test_path / "data" / "BSA1_ursgal_lookup.csv.bz2"
+    input_file = (
+        pytest._test_path / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
+    )
+
+    bp = IdentBaseParser(input_file, params={"rt_pickle_name": rt_lookup_path})
+    rt_lookup = bp._read_rt_lookup_file()
+    assert (rt_lookup["Unit"] == 1).all()
+    assert pytest.approx(
+        rt_lookup["Precursor mz"].mean(), 550.8444810049874
+    )  # check consistency
+    assert pytest.approx(rt_lookup.loc[2450, "Precursor mz"], 618.2697)
+    assert pytest.approx(rt_lookup.loc[2450, "RT"], 92067.714)
+
+
 def test_engine_parsers_IdentBaseParser_init():
     input_file = (
-        Path(__file__).parent / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
+        pytest._test_path / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
     )
-    rt_lookup_path = Path(__file__).parent / "data" / "_ursgal_lookup.csv.bz2"
-    db_path = Path(__file__).parent / "data" / "test_Creinhardtii_target_decoy.fasta"
+    rt_lookup_path = pytest._test_path / "data" / "_ursgal_lookup.csv.bz2"
+    db_path = pytest._test_path / "data" / "test_Creinhardtii_target_decoy.fasta"
 
     parser = IdentBaseParser(
         input_file,
@@ -56,7 +72,7 @@ def test_engine_parsers_IdentBaseParser_check_parser_compatibility_non_existing(
 def test_engine_parsers_IdentBaseParser_check_parser_compatibility_existing():
     # should always return False
     IdentBaseParser.check_parser_compatibility(
-        Path(__file__).parent / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
+        pytest._test_path / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
     ) is False
 
 
@@ -112,8 +128,7 @@ def test_add_protein_ids():
         input_file=None,
         params={
             "cpus": 2,
-            "database": Path(__file__).parent
-            / "data/test_Creinhardtii_target_decoy.fasta",
+            "database": pytest._test_path / "data/test_Creinhardtii_target_decoy.fasta",
         },
     )
     obj.df = pd.DataFrame(
@@ -147,7 +162,7 @@ def test_calc_masses_offsets_and_composition():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
         },
     )
     obj.df = pd.DataFrame(
@@ -179,7 +194,7 @@ def test_get_exp_rt_and_mz():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
         },
     )
     obj.df = pd.DataFrame(
@@ -269,7 +284,7 @@ def test_assert_only_iupac_and_missing_aas():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
         },
     )
     obj.df = pd.DataFrame(
@@ -287,7 +302,7 @@ def test_add_decoy_identity():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
         },
     )
     obj.df = pd.DataFrame(
@@ -306,7 +321,7 @@ def test_add_decoy_identity_non_default_prefix():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
             "decoy_tag": "non_default_tag_",
         },
     )
@@ -331,7 +346,7 @@ def test_check_enzyme_specificity_trypsin_all():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
             "enzyme": "trypsin",
             "terminal_cleavage_site_integrity": "all",
         },
@@ -355,7 +370,7 @@ def test_check_enzyme_specificity_trypsin_any():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
             "enzyme": "trypsin",
             "terminal_cleavage_site_integrity": "any",
         },
@@ -379,7 +394,7 @@ def test_check_enzyme_specificity_nonspecific():
         input_file=None,
         params={
             "cpus": 2,
-            "rt_pickle_name": Path(__file__).parent / "data/_ursgal_lookup.csv.bz2",
+            "rt_pickle_name": pytest._test_path / "data/_ursgal_lookup.csv.bz2",
             "enzyme": "nonspecific",
             "terminal_cleavage_site_integrity": "all",
         },

--- a/tests/test_engine_parser_quant_base_parser.py
+++ b/tests/test_engine_parser_quant_base_parser.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 from pathlib import Path
+import pytest
 
 from unify_idents.engine_parsers.base_parser import QuantBaseParser
 
 
 def test_engine_parsers_QuantBaseParser_init():
     input_file = (
-        Path(__file__).parent / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
+        pytest._test_path / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
     )
-    rt_lookup_path = Path(__file__).parent / "data" / "_ursgal_lookup.csv.bz2"
-    db_path = Path(__file__).parent / "data" / "test_Creinhardtii_target_decoy.fasta"
+    rt_lookup_path = pytest._test_path / "data" / "_ursgal_lookup.csv.bz2"
+    db_path = pytest._test_path / "data" / "test_Creinhardtii_target_decoy.fasta"
 
     parser = QuantBaseParser(
         input_file,
@@ -35,9 +36,7 @@ def test_engine_parsers_QuantBaseParser_check_parser_compatibility_existing():
     # should always return False
     assert (
         QuantBaseParser.check_parser_compatibility(
-            Path(__file__).parent
-            / "data"
-            / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
+            pytest._test_path / "data" / "test_Creinhardtii_QE_pH11_xtandem_alanine.xml"
         )
         is False
     )

--- a/unify_idents/engine_parsers/base_parser.py
+++ b/unify_idents/engine_parsers/base_parser.py
@@ -67,17 +67,6 @@ class BaseParser:
         """
         return False
 
-    def _read_rt_lookup_file(self):
-        """Read retention time lookup file.
-
-        Returns:
-            rt_lookup (pd.DataFrame): loaded rt_pickle_file indexable by Spectrum ID
-        """
-        rt_lookup = pd.read_csv(self.params["rt_pickle_name"], compression="bz2")
-        rt_lookup.set_index("Spectrum ID", inplace=True)
-        rt_lookup["Unit"] = rt_lookup["Unit"].replace({"second": 1, "minute": 60})
-        return rt_lookup
-
 
 class IdentBaseParser(BaseParser):
     """Base class of all ident parsers."""
@@ -306,6 +295,17 @@ class IdentBaseParser(BaseParser):
             * 1e6
         )
 
+    def _read_rt_lookup_file(self):
+        """Read retention time lookup file.
+
+        Returns:
+            rt_lookup (pd.DataFrame): loaded rt_pickle_file indexable by Spectrum ID
+        """
+        rt_lookup = pd.read_csv(self.params["rt_pickle_name"], compression="bz2")
+        rt_lookup.set_index("Spectrum ID", inplace=True)
+        rt_lookup["Unit"] = rt_lookup["Unit"].replace({"second": 1, "minute": 60})
+        return rt_lookup
+
     def get_exp_rt_and_mz(self):
         """Experimental mass-to-charge ratios and retention times are added.
 
@@ -431,7 +431,6 @@ class QuantBaseParser(BaseParser):
         """
         super().__init__(*args, **kwargs)
         self.cc = ChemicalComposition()
-        self.scan_rt_lookup = self._read_rt_lookup_file()
         self.required_headers = {
             "file_name",
             "spectrum_id",

--- a/unify_idents/engine_parsers/ident/mascot_2_6_2_parser.py
+++ b/unify_idents/engine_parsers/ident/mascot_2_6_2_parser.py
@@ -250,7 +250,9 @@ class Mascot_2_6_2_Parser(IdentBaseParser):
         logger.add(sys.stdout)
         self.df = pd.concat(chunk_dfs, axis=0, ignore_index=True)
         self.df.loc[:, "Spectrum Title"] = (
-            self.df["Spectrum Title"].str.replace("%2e", ".").str.replace(".mzML", "")
+            self.df["Spectrum Title"]
+            .str.replace("%2e", ".", regex=False)
+            .str.replace(".mzML", "", regex=False)
         )
         self.df.loc[:, "Calc m/z"] = self._calc_mz(
             mass=self.df["Exp m/z"], charge=self.df["Charge"]


### PR DESCRIPTION
 ... as it causes flashlfq conflicts for multiple input file szenarios and is not used in implemented quant parsers.

fixed various test related issues.