### PR TITLE
fix raw data location to ref mzml files to enable flashlfq integration more easily

### DIFF
--- a/tests/ident/test_engine_parser_comet_2020_01_04.py
+++ b/tests/ident/test_engine_parser_comet_2020_01_04.py
@@ -65,6 +65,7 @@ def test_engine_parsers_comet_check_dataframe_integrity():
             "cpus": 2,
             "rt_pickle_name": rt_lookup_path,
             "database": db_path,
+            "Raw data location": "path/for/glory.mzML",
             "modifications": [
                 {
                     "aa": "M",

--- a/tests/ident/test_engine_parser_mascot_2_6_2.py
+++ b/tests/ident/test_engine_parser_mascot_2_6_2.py
@@ -64,6 +64,7 @@ def test_engine_parsers_comet_check_dataframe_integrity():
             "cpus": 2,
             "rt_pickle_name": rt_lookup_path,
             "database": db_path,
+            "Raw data location": "path/for/glory.mzML",
             "modifications": [
                 {
                     "aa": "M",

--- a/tests/ident/test_engine_parser_msfragger_3.py
+++ b/tests/ident/test_engine_parser_msfragger_3.py
@@ -52,6 +52,7 @@ def test_engine_parsers_msfragger_check_dataframe_integrity():
             "cpus": 2,
             "rt_pickle_name": rt_lookup_path,
             "database": db_path,
+            "Raw data location": "path/for/glory.mzML",
             "modifications": [
                 {
                     "aa": "M",

--- a/tests/ident/test_engine_parser_msgfplus_2021_03_22.py
+++ b/tests/ident/test_engine_parser_msgfplus_2021_03_22.py
@@ -65,6 +65,7 @@ def test_engine_parsers_msgfplus_check_dataframe_integrity():
             "cpus": 2,
             "rt_pickle_name": rt_lookup_path,
             "database": db_path,
+            "Raw data location": "path/for/glory.mzML",
             "modifications": [
                 {
                     "aa": "M",

--- a/tests/ident/test_engine_parser_xtandem_alanine.py
+++ b/tests/ident/test_engine_parser_xtandem_alanine.py
@@ -72,6 +72,7 @@ def test_engine_parsers_xtandem_check_dataframe_integrity():
             "cpus": 2,
             "rt_pickle_name": rt_lookup_path,
             "database": db_path,
+            "Raw data location": "path/for/glory.mzML",
             "modifications": [
                 {
                     "aa": "M",

--- a/tests/test_engine_parser_ident_base_parser.py
+++ b/tests/test_engine_parser_ident_base_parser.py
@@ -80,7 +80,7 @@ def test_engine_parsers_IdentBase_Parser_sanitize():
     obj = IdentBaseParser(input_file=None, params=None)
     obj.mapping_dict = {"Engine:C": None, "Engine:B": None, "Engine:A": None}
     obj.df = pd.DataFrame(
-        np.ones((5, len(obj.col_order) + 4)),
+        np.random.random((5, len(obj.col_order) + 4)),
         columns=obj.col_order.to_list()
         + ["Engine:C", "Engine:B", "Engine:A", "This should not exist"],
     )

--- a/unify_idents/engine_parsers/base_parser.py
+++ b/unify_idents/engine_parsers/base_parser.py
@@ -89,7 +89,6 @@ class IdentBaseParser(BaseParser):
             "Exp m/z": None,
             "Calc m/z": None,
             "Spectrum Title": None,
-            "Raw data location": None,
             "Search Engine": None,
             "Spectrum ID": None,
             "Modifications": None,
@@ -357,6 +356,7 @@ class IdentBaseParser(BaseParser):
         - Columns in the dataframe which could not be properly mapped are removed (warning is raised)
         Operations are performed inplace on self.df
         """
+        self.df["Raw data location"] = self.params.get("Raw data location", "")
         missing_data_locs = ~(self.df["Raw data location"].str.len() > 0)
         self.df.loc[missing_data_locs, "Raw data location"] = (
             self.df.loc[missing_data_locs, "Spectrum Title"].str.split(".").str[0]

--- a/unify_idents/engine_parsers/ident/comet_2020_01_4_parser.py
+++ b/unify_idents/engine_parsers/ident/comet_2020_01_4_parser.py
@@ -63,19 +63,11 @@ class Comet_2020_01_4_Parser(IdentBaseParser):
 
         tree = ETree.parse(self.input_file)
         self.root = tree.getroot()
-        self.reference_dict.update(
-            {
-                "Raw data location": self.root.find(
-                    ".//{*}DataCollection/{*}Inputs/{*}SpectraData"
-                ).attrib["location"],
-                "Search Engine": "comet_"
-                + "_".join(
-                    re.findall(
-                        r"([/d]*\d+)",
-                        self.root.find(".//{*}AnalysisSoftware").attrib["version"],
-                    )
-                ),
-            }
+        self.reference_dict["Search Engine"] = "comet_" + "_".join(
+            re.findall(
+                r"([/d]*\d+)",
+                self.root.find(".//{*}AnalysisSoftware").attrib["version"],
+            )
         )
         self.mapping_dict = {
             v: k
@@ -199,8 +191,11 @@ class Comet_2020_01_4_Parser(IdentBaseParser):
         logger.add(sys.stdout)
         self.df = pd.concat(chunk_dfs, axis=0, ignore_index=True)
         self._map_mods_and_sequences()
+        spec_title = re.search(
+            r"(?<=/)([\w_]+)(?=\.)", self.params["Raw data location"]
+        ).group(0)
         self.df.loc[:, "Spectrum Title"] = (
-            self.df["Raw data location"].str.extract(r"(?<=/)([\w_]+)(?=\.)")[0]
+            spec_title
             + "."
             + self.df["Spectrum ID"]
             + "."

--- a/unify_idents/engine_parsers/ident/mascot_2_6_2_parser.py
+++ b/unify_idents/engine_parsers/ident/mascot_2_6_2_parser.py
@@ -79,17 +79,9 @@ class Mascot_2_6_2_Parser(IdentBaseParser):
             ),
         }
 
-        self.reference_dict.update(
-            {
-                "Raw data location": re.search(
-                    r"(?<=FILE=).*", self.section_data["parameters"]
-                ).group(),
-                "Search Engine": "mascot_"
-                + re.search(r"(?<=version=).*", self.section_data["header"])
-                .group()
-                .replace(".", "_"),
-            }
-        )
+        self.reference_dict["Search Engine"] = "mascot_" + re.search(
+            r"(?<=version=).*", self.section_data["header"]
+        ).group().replace(".", "_")
         self.reference_dict["Mascot:Score"] = None
 
     @classmethod

--- a/unify_idents/engine_parsers/ident/msamanda_2_parser.py
+++ b/unify_idents/engine_parsers/ident/msamanda_2_parser.py
@@ -105,7 +105,6 @@ class MSAmanda_2_Parser(IdentBaseParser):
             self.df (pd.DataFrame): unified dataframe
         """
         self.df["Search Engine"] = "msamanda_2_0_0_17442"
-        self.df["Raw data location"] = self.params["Raw data location"]
         self.df["Spectrum ID"] = self.df["Spectrum Title"].str.split(".").str[1]
         self.df["Modifications"] = self.translate_mods()
         self.process_unify_style()

--- a/unify_idents/engine_parsers/ident/msfragger_3_parser.py
+++ b/unify_idents/engine_parsers/ident/msfragger_3_parser.py
@@ -182,12 +182,13 @@ class MSFragger_3_Parser(IdentBaseParser):
             self.df (pd.DataFrame): unified dataframe
         """
         self.df["Search Engine"] = "msfragger_3_0"
-        self.df["Raw data location"] = str(self.params["Raw data location"])
-        spec_title = (
-            self.df["Raw data location"].str.split(".").str[0].str.split("/").str[-1]
-        )
+        spec_title = re.search(
+            r"(?<=/)([\w_]+)(?=\.)", self.params["Raw data location"]
+        ).group(0)
         self.df["Spectrum Title"] = (
             spec_title
+            + "."
+            + self.df["Spectrum ID"].astype(str)
             + "."
             + self.df["Spectrum ID"].astype(str)
             + "."

--- a/unify_idents/engine_parsers/ident/msgfplus_2021_03_22_parser.py
+++ b/unify_idents/engine_parsers/ident/msgfplus_2021_03_22_parser.py
@@ -82,19 +82,11 @@ class MSGFPlus_2021_03_22_Parser(IdentBaseParser):
 
         tree = ETree.parse(self.input_file)
         self.root = tree.getroot()
-        self.reference_dict.update(
-            {
-                "Raw data location": self.root.find(".//{*}SpectraData").attrib[
-                    "location"
-                ],
-                "Search Engine": "msgfplus_"
-                + "_".join(
-                    re.findall(
-                        r"([/d]*\d+)",
-                        self.root.find(".//{*}AnalysisSoftware").attrib["version"],
-                    )
-                ),
-            }
+        self.reference_dict["Search Engine"] = "msgfplus_" + "_".join(
+            re.findall(
+                r"([/d]*\d+)",
+                self.root.find(".//{*}AnalysisSoftware").attrib["version"],
+            )
         )
         self.mapping_dict = {
             v: k

--- a/unify_idents/engine_parsers/ident/omssa_2_1_9_parser.py
+++ b/unify_idents/engine_parsers/ident/omssa_2_1_9_parser.py
@@ -255,9 +255,6 @@ class Omssa_Parser(IdentBaseParser):
         self.df["Spectrum ID"] = (
             self.df["Spectrum Title"].str.split(".").str[1].astype(int)
         )
-        self.df["Raw data location"] = self.params.get(
-            "Raw data location", self.df["Spectrum Title"].str.split(".").str[0]
-        )
         self.df["Search Engine"] = "omssa_2_1_9"
         self.df["Modifications"] = self.translate_mods()
         self.process_unify_style()

--- a/unify_idents/engine_parsers/ident/xtandem_alanine.py
+++ b/unify_idents/engine_parsers/ident/xtandem_alanine.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ETree
 from itertools import repeat
 
 import pandas as pd
+import regex as re
 from loguru import logger
 from tqdm import tqdm
 
@@ -71,7 +72,17 @@ class XTandemAlanine_Parser(IdentBaseParser):
         self.style = "xtandem_style_1"
         tree = ETree.parse(self.input_file)
         self.root = tree.getroot()
-        self.reference_dict["Search Engine"] = "xtandem_alanine"
+        self.reference_dict["Search Engine"] = (
+            "xtandem_"
+            + re.search(
+                r"(?<=Tandem )\w+",
+                self.root.find(
+                    './/*[@label="performance parameters"]/*[@label="process, version"]'
+                ).text,
+            )
+            .group()
+            .lower()
+        )
         self.mapping_dict = {
             v: k
             for k, v in self.param_mapper.get_default_params(style=self.style)[

--- a/unify_idents/engine_parsers/ident/xtandem_alanine.py
+++ b/unify_idents/engine_parsers/ident/xtandem_alanine.py
@@ -71,14 +71,7 @@ class XTandemAlanine_Parser(IdentBaseParser):
         self.style = "xtandem_style_1"
         tree = ETree.parse(self.input_file)
         self.root = tree.getroot()
-        self.reference_dict.update(
-            {
-                "Raw data location": self.root.attrib["label"]
-                .split("models from ")[1]
-                .replace("'", ""),
-                "Search Engine": "xtandem_alanine",
-            }
-        )
+        self.reference_dict["Search Engine"] = "xtandem_alanine"
         self.mapping_dict = {
             v: k
             for k, v in self.param_mapper.get_default_params(style=self.style)[

--- a/unify_idents/engine_parsers/quant/flash_lfq_1_2_0_parser.py
+++ b/unify_idents/engine_parsers/quant/flash_lfq_1_2_0_parser.py
@@ -1,7 +1,9 @@
 """Quant parser."""
-import pandas as pd
 import re
 from pathlib import Path
+
+import pandas as pd
+
 from unify_idents.engine_parsers.base_parser import QuantBaseParser
 
 


### PR DESCRIPTION
set raw data location in ident base parser. it should in all cases have been extracted previously by the wrapper from the history ufiles and will therefore be available.