### PR TITLE
dont round mod masses

### DIFF
--- a/unify_idents/engine_parsers/ident/msfragger_3_parser.py
+++ b/unify_idents/engine_parsers/ident/msfragger_3_parser.py
@@ -125,9 +125,7 @@ class MSFragger_3_Parser(IdentBaseParser):
         potential_names = {
             m: [
                 name
-                for name in self.mod_mapper.mass_to_names(
-                    round(float(m), 4), decimals=4
-                )
+                for name in self.mod_mapper.mass_to_names(float(m), decimals=4)
                 if name in self.mod_dict
             ]
             for m in unique_mod_masses
@@ -138,7 +136,7 @@ class MSFragger_3_Parser(IdentBaseParser):
                 potential_mods = [
                     name[1]
                     for name in self.mod_mapper.mass_to_combos(
-                        round(float(unmapped_mass), 4), n=n, decimals=4
+                        float(unmapped_mass), n=n, decimals=4
                     )
                     if all(m in self.mod_dict for m in name[1])
                 ]

--- a/unify_idents/engine_parsers/ident/xtandem_alanine.py
+++ b/unify_idents/engine_parsers/ident/xtandem_alanine.py
@@ -127,9 +127,7 @@ class XTandemAlanine_Parser(IdentBaseParser):
         potential_names = {
             m: [
                 name
-                for name in self.mod_mapper.mass_to_names(
-                    round(float(m), 4), decimals=4
-                )
+                for name in self.mod_mapper.mass_to_names(float(m), decimals=4)
                 if name in self.mod_dict
             ]
             for m in unique_mod_masses


### PR DESCRIPTION
Do not round mod masses  when mapping mass to name, since this leads to mapping issues with e.g. TMTpro